### PR TITLE
Fix a problem of stream when requiring twice

### DIFF
--- a/luasrc/init.lua
+++ b/luasrc/init.lua
@@ -1,3 +1,18 @@
+-- Force to include randomkit once only, relying on the global state
+-- NB: it is ugly to rely on the fact that we pollute the global
+-- namespace, yet I do not see a better way to avoid 
+-- including ourselves twice -- which would cause seed problems.
+--
+-- This will need deeper consideration once we will return only
+-- a local table, and once we will want proper multi-thread
+-- support. In particular, we will have to modify the interfacing
+-- with torch.[gs]etRNGState in wrapC.lua.
+--
+-- But for now (November 2013), this is good enough.
+if randomkit then
+    return randomkit
+end
+
 randomkit = {}
 
 function randomkit._isTensor(v)

--- a/luasrc/tests/testMultipleRequire.lua
+++ b/luasrc/tests/testMultipleRequire.lua
@@ -14,10 +14,10 @@ function myTests.test_beta()
 
     -- call N with require between each another
     torch.setRNGState(state)
-    local y = torch.Tensor(N)
+    local multipleRequire = torch.Tensor(N)
     for i=1,N do
         require 'randomkit'
-        y[i] = randomkit.gauss()
+        multipleRequire[i] = randomkit.gauss()
     end
 
     -- The streams should be the same


### PR DESCRIPTION
Very important, since multiple sublibraries might require
each randomkit.

For now the fix detects that we already included randomkit 
using  the fact that we pollute the global namespace.
That is really ugly, but will do for now.

@d11, can you check and merge, please ?
