### PR TITLE
Avoided a warning about reading an undefined var.

### DIFF
--- a/luasrc/init.lua
+++ b/luasrc/init.lua
@@ -9,7 +9,7 @@
 -- with torch.[gs]etRNGState in wrapC.lua.
 --
 -- But for now (November 2013), this is good enough.
-if randomkit then
+if rawget(_G, "randomkit") then
     return randomkit
 end
 


### PR DESCRIPTION
With the proposed change, it will be possible to require util.warn before randomkit.
