### PR TITLE
Fix problems with absolute value function.

### DIFF
--- a/randomkit/distributions.c
+++ b/randomkit/distributions.c
@@ -44,6 +44,7 @@
 #include <math.h>
 #include "distributions.h"
 #include <stdio.h>
+#include <stdlib.h>
 
 #ifndef min
 #define min(x,y) ((x<y)?x:y)
@@ -315,7 +316,7 @@ long rk_binomial_btpe(rk_state *state, long n, double p)
     v = v*(u-p3)*lamr;
 
   Step50:
-    k = fabs(y - m);
+    k = labs(y - m);
     if ((k > 20) && (k < ((nrq)/2.0 - 1))) goto Step52;
 
     s = r/q;


### PR DESCRIPTION
The standard library provides seven absolute value functions.  From C,
there is abs, labs, llabs, fabs, fabsf, and fabsl for the types int,
long, long long, double, float and long double.  Due to numeric
conversions, these functions can accept arguments of any numeric types,
silently converting between types.  This change replaces fabs, which is
for double arguments, with labs, which is for long arguments.