### PR TITLE
Fix test with serial dependency.

### DIFF
--- a/luasrc/tests/testMultipleRequire.lua
+++ b/luasrc/tests/testMultipleRequire.lua
@@ -10,7 +10,6 @@ function myTests.test_beta()
 
     -- Call N in one go
     require 'randomkit'
-    local ignored = torch.rand(1)
     local state = torch.getRNGState()
     randomkit.gauss(oneRequire)
 

--- a/luasrc/tests/testMultipleRequire.lua
+++ b/luasrc/tests/testMultipleRequire.lua
@@ -10,7 +10,8 @@ function myTests.test_beta()
 
     -- Call N in one go
     require 'randomkit'
-    state = torch.getRNGState()
+    local ignored = torch.rand(1)
+    local state = torch.getRNGState()
     randomkit.gauss(oneRequire)
 
     -- call N with require between each another

--- a/luasrc/tests/testSeed.lua
+++ b/luasrc/tests/testSeed.lua
@@ -29,11 +29,10 @@ function seedTest.testManualSeed()
 end
 
 function seedTest.testRNGState()
-   local ignored, state, stateCloned, before, after
+   local state, stateCloned, before, after
 
     local function test_generator(f, s)
         s = s or ''
-        ignored = f()
         state = torch.getRNGState()
         before = f()
         torch.setRNGState(state)


### PR DESCRIPTION
- torch.rand() must be called before torch.getRNGState() to ensure the
  state is defined.
- Added a 'local' keyword.