### PR TITLE
Adjust setRNGState so that it updates the pointer to the main Torch generator.

### DIFF
--- a/luasrc/tests/testWrap.lua
+++ b/luasrc/tests/testWrap.lua
@@ -54,6 +54,21 @@ function myTest.callsetRNGWithGenerator()
     tester:assert(ok, 'Failed to set RNG state')
 end
 
+function myTest.setRNGWithBadPointer()
+  -- To simulate restoring the state from a previous run, we invalidate the
+  -- pointer to the main Torch generator in a state that we are passing to
+  -- setRNGState, and check that this doesn't break things.
+  local state = torch.getRNGState()
+  local x = tonumber(randomkit.binomial(10, 0.4))
+  local badState = ffi.cast("rk_state *", state.randomkit)
+  badState.torch_state = ffi.cast("THGenerator*", 0)
+  torch.setRNGState{
+      torch = state.torch,
+      randomkit = badState
+  }
+  tester:asserteq(x, tonumber(randomkit.binomial(10, 0.4)))
+end
+
 
 tester:add(myTest)
 return tester:run()

--- a/luasrc/wrapC.lua
+++ b/luasrc/wrapC.lua
@@ -199,7 +199,7 @@ end
 
 local _setRNGState = torch.setRNGState
 torch.setRNGState = function(generator, state)
-    if state then 
+    if state then
       return _setRNGState(generator, state)
     else
       state = generator

--- a/luasrc/wrapC.lua
+++ b/luasrc/wrapC.lua
@@ -210,6 +210,12 @@ torch.setRNGState = function(generator, state)
     _setRNGState(state.torch)
     -- Deserialize from string
     ffi.copy(randomkit._state, state.randomkit, ffi.sizeof(randomkit._state))
+
+    -- If the state being set is from a previous run, the pointer to the main
+    -- Torch generator will no longer be valid. So we will explicitly update the
+    -- pointer to be current.
+    randomkit._state.torch_state =
+        ffi.cast("THGenerator*", torch.pointer(torch._gen))
 end
 
 local returnTypeMapping = {


### PR DESCRIPTION
This is necessary to handle restoring states from previous runs correctly.

Also added a unit test that fails without the new change.